### PR TITLE
Rafawo/update win10sdk version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,4 @@ winapi = { version = "0.3.6", features = [
     "winerror",
     "winioctl",
 ] }
-winutils-rs = "0.1.2"
+winutils-rs = "0.1.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,4 @@ winapi = { version = "0.3.6", features = [
     "winerror",
     "winioctl",
 ] }
-winutils-rs = "0.1.6"
+winutils-rs = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["api-bindings", "os::windows-apis"]
 build = "build.rs"
 
 [dependencies]
+bytefmt = "0.1.7"
 widestring = "0.4.0"
 winapi = { version = "0.3.6", features = [
     "errhandlingapi",

--- a/README.md
+++ b/README.md
@@ -45,3 +45,37 @@ Finally, open documentation by running:
 ```
 cargo doc --open
 ```
+
+## Crates.io version notes
+
+This section briefly describes all published crates.io [versions](https://crates.io/crates/virtdisk-rs/versions) of this project, ordered from latest to oldest.
+
+- [**2.0.0 Jul 31, 2019**](https://crates.io/crates/virtdisk-rs/2.0.0)
+  - Updated hardcoded dependency to Windows 10 SDK version 10.0.18362.0
+  - Subtle dependencies to Windows RS5
+- [**1.5.0 Jan 4, 2019**](https://crates.io/crates/virtdisk-rs/1.5.0)
+  - Oldest stable version
+  - Containers VHD and Disk utilities to aid container storage setup
+  - API is tentatively finalized for this crate
+  - Hardcoded dependency to Windows 10 SDK version 10.0.17763.0
+  - Implementation has subtle dependencies to Windows RS4
+- [**1.4.0 Jan 3, 2019**](https://crates.io/crates/virtdisk-rs/1.4.0)
+  - **YANKED, DO NOT USE**
+- [**1.3.0 Jan 3, 2019**](https://crates.io/crates/virtdisk-rs/1.3.0)
+  - **YANKED, DO NOT USE**
+- [**1.2.0 Jan 3, 2019**](https://crates.io/crates/virtdisk-rs/1.2.0)
+  - **YANKED, DO NOT USE**
+- [**1.1.1 Jan 2, 2019**](https://crates.io/crates/virtdisk-rs/1.1.1)
+  - **YANKED, DO NOT USE**
+- [**1.1.0 Jan 2, 2019**](https://crates.io/crates/virtdisk-rs/1.1.0)
+  - **YANKED, DO NOT USE**
+- [**1.0.1 Dec 31, 2018**](https://crates.io/crates/virtdisk-rs/1.0.1)
+  - **YANKED, DO NOT USE**
+- [**1.0.0 Dec 28, 2018**](https://crates.io/crates/virtdisk-rs/1.0.0)
+  - **YANKED, DO NOT USE**
+- [**0.1.2 Dec 20, 2018**](https://crates.io/crates/virtdisk-rs/0.1.2)
+  - **YANKED, DO NOT USE**
+- [**0.1.1 Dec 20, 2018**](https://crates.io/crates/virtdisk-rs/0.1.1)
+  - **YANKED, DO NOT USE**
+- [**0.1.0 Dec 19, 2018**](https://crates.io/crates/virtdisk-rs/0.1.0)
+  - **YANKED, DO NOT USE**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ VirtDisk APIs are part of the [Windows 10 SDK](https://developer.microsoft.com/e
 
 For this wrapper to build properly, the following requirements need to be met by the building machine:
 
-- Windows 10 SDK version **10.0.17763.132**.
+- Windows 10 SDK version **10.0.18362.0**.
 - **amd64** architecture.
   - This Rust wrapper, for now, expects to build only in amd64.
 
@@ -22,8 +22,8 @@ For this wrapper to build properly, the following requirements need to be met by
 **_Note: This section includes the paths in the Windows SDK for the header and lib files based on the default installation path `c:\Program Files (x86)\Windows Kits\10`._**
 
 The relevant Windows 10 SDK files that this project is wrapping are:
-- C:\Program Files (x86)\Windows Kits\10\Include\10.0.17763.0\um\virtdisk.h
-- C:\Program Files (x86)\Windows Kits\10\Lib\10.0.17763.0\um\x64\virtdisk.lib
+- C:\Program Files (x86)\Windows Kits\10\Include\10.0.18362.0\um\virtdisk.h
+- C:\Program Files (x86)\Windows Kits\10\Lib\10.0.18362.0\um\x64\virtdisk.lib
 - C:\Windows\System32\virtdisk.dll
 
 ## How to use locally
@@ -34,7 +34,7 @@ Clone the repo to a folder:
 git clone https://github.com/rafawo/virtdisk-rs.git
 ```
 
-Make sure the machine where you are building has Windows 10 SDK version Windows 10 SDK version **10.0.17763.132** installed. Then run:
+Make sure the machine where you are building has Windows 10 SDK version **10.0.17763.132** installed. Then run:
 
 ```
 cd virtdisk-rs

--- a/build.rs
+++ b/build.rs
@@ -11,7 +11,7 @@
 //!
 //! This script relies on the environment variables `WIN10SDK_PATH` and `WIN10SDK_VERSION`.
 //! `WIN10SDK_PATH` defaults to `c:\Program Files (x86)\Windows Kits\10` if not set.
-//! `WIN10SDK_VERSION` defaults to `10.0.17763.0` if not set.
+//! `WIN10SDK_VERSION` defaults to `10.0.18362.0` if not set.
 
 use std::env::var;
 
@@ -26,7 +26,7 @@ fn main() {
 
     let win10_sdk_version = match var("WIN10SDK_VERSION") {
         Ok(path) => path,
-        Err(_) => String::from("10.0.17763.0"),
+        Err(_) => String::from("10.0.18362.0"),
     };
 
     let lib_names = vec![String::from("virtdisk")];

--- a/src/diskutilities.rs
+++ b/src/diskutilities.rs
@@ -956,7 +956,7 @@ pub fn get_ntfsinfo(volume_path: &str) -> WinResult<NtFileSystemInfo> {
         if splitted.len() == 2 {
             match splitted[0].trim() {
                 "NTFS Volume Serial Number" => {
-                    let hex_value = splitted[1].trim().trim_left_matches("0x");
+                    let hex_value = splitted[1].trim().trim_start_matches("0x");
                     ntfsinfo.ntfs_volume_serial_number =
                         u64::from_str_radix(hex_value, 16).unwrap();
                 }
@@ -967,19 +967,19 @@ pub fn get_ntfsinfo(volume_path: &str) -> WinResult<NtFileSystemInfo> {
                     ntfsinfo.lfs_version = String::from(splitted[1].trim());
                 }
                 "Number Sectors" => {
-                    let hex_value = splitted[1].trim().trim_left_matches("0x");
+                    let hex_value = splitted[1].trim().trim_start_matches("0x");
                     ntfsinfo.number_sectors = u64::from_str_radix(hex_value, 16).unwrap();
                 }
                 "Total Clusters" => {
-                    let hex_value = splitted[1].trim().trim_left_matches("0x");
+                    let hex_value = splitted[1].trim().trim_start_matches("0x");
                     ntfsinfo.total_clusters = u64::from_str_radix(hex_value, 16).unwrap();
                 }
                 "Free Clusters" => {
-                    let hex_value = splitted[1].trim().trim_left_matches("0x");
+                    let hex_value = splitted[1].trim().trim_start_matches("0x");
                     ntfsinfo.free_clusters = u64::from_str_radix(hex_value, 16).unwrap();
                 }
                 "Total Reserved" => {
-                    let hex_value = splitted[1].trim().trim_left_matches("0x");
+                    let hex_value = splitted[1].trim().trim_start_matches("0x");
                     ntfsinfo.total_reserved = u64::from_str_radix(hex_value, 16).unwrap();
                 }
                 "Bytes Per Sector" => {
@@ -1000,23 +1000,23 @@ pub fn get_ntfsinfo(volume_path: &str) -> WinResult<NtFileSystemInfo> {
                         splitted[1].trim().parse::<u32>().unwrap();
                 }
                 "Mft Valid Data Length" => {
-                    let hex_value = splitted[1].trim().trim_left_matches("0x");
+                    let hex_value = splitted[1].trim().trim_start_matches("0x");
                     ntfsinfo.mft_valid_data_length = u64::from_str_radix(hex_value, 16).unwrap();
                 }
                 "Mft Start Lcn" => {
-                    let hex_value = splitted[1].trim().trim_left_matches("0x");
+                    let hex_value = splitted[1].trim().trim_start_matches("0x");
                     ntfsinfo.mft_start_lcn = u64::from_str_radix(hex_value, 16).unwrap();
                 }
                 "Mft2 Start Lcn" => {
-                    let hex_value = splitted[1].trim().trim_left_matches("0x");
+                    let hex_value = splitted[1].trim().trim_start_matches("0x");
                     ntfsinfo.mft2_start_lcn = u64::from_str_radix(hex_value, 16).unwrap();
                 }
                 "Mft Zone Start" => {
-                    let hex_value = splitted[1].trim().trim_left_matches("0x");
+                    let hex_value = splitted[1].trim().trim_start_matches("0x");
                     ntfsinfo.mft_zone_start = u64::from_str_radix(hex_value, 16).unwrap();
                 }
                 "Mft Zone End" => {
-                    let hex_value = splitted[1].trim().trim_left_matches("0x");
+                    let hex_value = splitted[1].trim().trim_start_matches("0x");
                     ntfsinfo.mft_zone_end = u64::from_str_radix(hex_value, 16).unwrap();
                 }
                 "Max Device Trim Extent Count" => {
@@ -1024,7 +1024,7 @@ pub fn get_ntfsinfo(volume_path: &str) -> WinResult<NtFileSystemInfo> {
                         splitted[1].trim().parse::<u32>().unwrap();
                 }
                 "Max Device Trim Byte Count" => {
-                    let hex_value = splitted[1].trim().trim_left_matches("0x");
+                    let hex_value = splitted[1].trim().trim_start_matches("0x");
                     ntfsinfo.max_device_trim_byte_count =
                         u32::from_str_radix(hex_value, 16).unwrap();
                 }
@@ -1033,7 +1033,7 @@ pub fn get_ntfsinfo(volume_path: &str) -> WinResult<NtFileSystemInfo> {
                         splitted[1].trim().parse::<u32>().unwrap();
                 }
                 "Max Volume Trim Byte Count" => {
-                    let hex_value = splitted[1].trim().trim_left_matches("0x");
+                    let hex_value = splitted[1].trim().trim_start_matches("0x");
                     ntfsinfo.max_volume_trim_byte_count =
                         u32::from_str_radix(hex_value, 16).unwrap();
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,8 +27,8 @@
 //! **_Note: This section includes the paths in the Windows SDK for the header and lib files based on the default installation path `c:\Program Files (x86)\Windows Kits\10`._**
 //!
 //! The relevant Windows 10 SDK files that this project is wrapping are:
-//! - C:\Program Files (x86)\Windows Kits\10\Include\10.0.17763.0\um\virtdisk.h
-//! - C:\Program Files (x86)\Windows Kits\10\Lib\10.0.17763.0\um\x64\virtdisk.lib
+//! - C:\Program Files (x86)\Windows Kits\10\Include\10.0.18362.0\um\virtdisk.h
+//! - C:\Program Files (x86)\Windows Kits\10\Lib\10.0.18362.0\um\x64\virtdisk.lib
 //! - C:\Windows\System32\virtdisk.dll
 //!
 

--- a/src/vhdutilities.rs
+++ b/src/vhdutilities.rs
@@ -11,7 +11,9 @@
 use crate::diskutilities::*;
 use crate::virtdisk::*;
 use crate::virtdiskdefs::*;
-use winutils_rs::errorcodes::{error_code_to_result_code, result_code_to_error_code, ResultCode};
+use winutils_rs::errorcodes::{
+    error_code_to_winresult_code, winresult_code_to_error_code, WinResult, WinResultCode,
+};
 use winutils_rs::utilities::*;
 use winutils_rs::windefs::*;
 
@@ -22,11 +24,7 @@ pub struct MountedVolume {
 }
 
 /// Creates a new VHD specified by filename.
-pub fn create_vhd(
-    filename: &str,
-    disk_size_gb: u64,
-    block_size_mb: u32,
-) -> Result<VirtualDisk, ResultCode> {
+pub fn create_vhd(filename: &str, disk_size_gb: u64, block_size_mb: u32) -> WinResult<VirtualDisk> {
     let mut parameters = unsafe { std::mem::zeroed::<create_virtual_disk::Parameters>() };
     parameters.version = create_virtual_disk::Version::Version2;
     unsafe {
@@ -53,11 +51,7 @@ pub fn create_vhd(
 
 /// Mounts the given VHD into the host.
 /// The flags are a u32 representation of any valid combination from `attach_virtual_disk::Flag` values.
-pub fn mount_vhd(
-    virtual_disk: &VirtualDisk,
-    flags: u32,
-    cache_mode: u16,
-) -> Result<(), ResultCode> {
+pub fn mount_vhd(virtual_disk: &VirtualDisk, flags: u32, cache_mode: u16) -> WinResult<()> {
     use winapi::um::{errhandlingapi, ioapiset, winnt};
 
     let manage_volume = TemporaryPrivilege::new(winnt::SE_MANAGE_VOLUME_NAME);
@@ -91,7 +85,7 @@ pub fn mount_vhd(
             std::ptr::null_mut(),
         ) == 0
         {
-            return Err(error_code_to_result_code(errhandlingapi::GetLastError()));
+            return Err(error_code_to_winresult_code(errhandlingapi::GetLastError()));
         }
     }
 
@@ -111,7 +105,7 @@ pub fn mount_vhd(
 /// Mounts a VHD with temporarily lifetime and without respecting flushes.
 /// The expectation is that this is only called during setup, where if there is
 /// a power failure the file would be deleted anyway.
-pub fn mount_vhd_temporarily_for_setup(virtual_disk: &VirtualDisk) -> Result<(), ResultCode> {
+pub fn mount_vhd_temporarily_for_setup(virtual_disk: &VirtualDisk) -> WinResult<()> {
     mount_vhd(
         virtual_disk,
         attach_virtual_disk::Flag::NoDriveLetter as u32
@@ -122,7 +116,7 @@ pub fn mount_vhd_temporarily_for_setup(virtual_disk: &VirtualDisk) -> Result<(),
 
 /// Attaches a VHD with permanent lifetime, respecting all flushes (but cache metadata in VHDX),
 /// and ensure there is no extra security descriptor applied to the volume object.
-pub fn mount_vhd_permanently_for_use(virtual_disk: &VirtualDisk) -> Result<(), ResultCode> {
+pub fn mount_vhd_permanently_for_use(virtual_disk: &VirtualDisk) -> WinResult<()> {
     mount_vhd(
         virtual_disk,
         attach_virtual_disk::Flag::NoDriveLetter as u32
@@ -134,12 +128,12 @@ pub fn mount_vhd_permanently_for_use(virtual_disk: &VirtualDisk) -> Result<(), R
 }
 
 /// Dismounts the given VHD from the host.
-pub fn dismount_vhd(virtual_disk: &VirtualDisk) -> Result<(), ResultCode> {
+pub fn dismount_vhd(virtual_disk: &VirtualDisk) -> WinResult<()> {
     virtual_disk.detach(detach_virtual_disk::Flag::None as u32, 0)
 }
 
 /// Opens a VHD for use as a container sandbox and returns a safe wrapper over the handle.
-pub fn open_vhd(filename: &str, read_only: bool) -> Result<VirtualDisk, ResultCode> {
+pub fn open_vhd(filename: &str, read_only: bool) -> WinResult<VirtualDisk> {
     let default_storage_type = VirtualStorageType {
         device_id: 0,
         vendor_id: VIRTUAL_STORAGE_TYPE_VENDOR_UNKNOWN,
@@ -172,7 +166,7 @@ pub fn create_base_vhd(
     disk_size_gb: u64,
     block_size_mb: u32,
     file_system: &str,
-) -> Result<MountedVolume, ResultCode> {
+) -> WinResult<MountedVolume> {
     let virtual_disk = create_vhd(filename, disk_size_gb, block_size_mb)?;
     mount_vhd_temporarily_for_setup(&virtual_disk)?;
     let disk = open_vhd_backed_disk(&virtual_disk)?;
@@ -185,11 +179,7 @@ pub fn create_base_vhd(
 }
 
 /// Creates a new diff VHD specified by filename based on the given parent disk.
-pub fn create_diff_vhd(
-    filename: &str,
-    parent_name: &str,
-    block_size_mb: u32,
-) -> Result<(), ResultCode> {
+pub fn create_diff_vhd(filename: &str, parent_name: &str, block_size_mb: u32) -> WinResult<()> {
     assert!(block_size_mb <= 256);
     let mut block_size_in_bytes = block_size_mb * 1024 * 1024;
 
@@ -248,7 +238,7 @@ pub fn create_vhd_from_source(
     filename: &str,
     source_filename: &str,
     block_size_mb: u32,
-) -> Result<(), ResultCode> {
+) -> WinResult<()> {
     let source_path_wstr = widestring::WideCString::from_str(source_filename).unwrap();
     let mut parameters = unsafe { std::mem::zeroed::<create_virtual_disk::Parameters>() };
     parameters.version = create_virtual_disk::Version::Version2;
@@ -278,13 +268,13 @@ pub fn create_vhd_from_source(
 }
 
 /// Finds the given mounted VHD and returns the resulting volume path.
-pub fn get_vhd_volume_path(virtual_disk: &VirtualDisk) -> Result<String, ResultCode> {
+pub fn get_vhd_volume_path(virtual_disk: &VirtualDisk) -> WinResult<String> {
     let disk = open_vhd_backed_disk(&virtual_disk)?;
     disk.volume_path()
 }
 
 /// Determines the VHD path of the VHD hosting a volume or file within the volume.
-pub fn get_vhd_from_filename(filename: &str) -> Result<String, ResultCode> {
+pub fn get_vhd_from_filename(filename: &str) -> WinResult<String> {
     use winapi::um::{fileapi, winnt};
 
     let file = create_file(
@@ -302,13 +292,13 @@ pub fn get_vhd_from_filename(filename: &str) -> Result<String, ResultCode> {
         storage_dependency::GetFlag::HostVolumes as u32,
         storage_dependency::InfoVersion::Version2,
     ) {
-        Err(ResultCode::WindowsErrorCode(error))
+        Err(WinResultCode::WindowsErrorCode(error))
             if error == winapi::shared::winerror::ERROR_VIRTDISK_NOT_VIRTUAL_DISK as u32 =>
         {
             return Ok(String::from(""));
         }
         Err(error)
-            if result_code_to_error_code(error)
+            if winresult_code_to_error_code(error)
                 == winapi::shared::winerror::ERROR_VIRTDISK_NOT_VIRTUAL_DISK as u32 =>
         {
             return Ok(String::from(""));
@@ -336,13 +326,13 @@ pub fn get_vhd_from_filename(filename: &str) -> Result<String, ResultCode> {
                 string.shrink_to_fit();
                 Ok(string)
             }
-            _ => Err(ResultCode::ErrorGenFailure),
+            _ => Err(WinResultCode::ErrorGenFailure),
         }
     }
 }
 
 /// Sets the caching mode on a mounted VHD.
-pub fn set_vhd_caching_mode(virtual_disk: &VirtualDisk, cache_mode: u16) -> Result<(), ResultCode> {
+pub fn set_vhd_caching_mode(virtual_disk: &VirtualDisk, cache_mode: u16) -> WinResult<()> {
     #[repr(C)]
     struct CachePolicyRequest {
         request_level: u32,
@@ -367,7 +357,7 @@ pub fn set_vhd_caching_mode(virtual_disk: &VirtualDisk, cache_mode: u16) -> Resu
             &mut bytes,
             std::ptr::null_mut(),
         ) {
-            0 => Err(error_code_to_result_code(
+            0 => Err(error_code_to_winresult_code(
                 winapi::um::errhandlingapi::GetLastError(),
             )),
             _ => Ok(()),
@@ -376,13 +366,13 @@ pub fn set_vhd_caching_mode(virtual_disk: &VirtualDisk, cache_mode: u16) -> Resu
 }
 
 /// Returns the size of the VHD on the physical disk.
-pub fn get_physical_vhd_size_in_kb(virtual_disk: &VirtualDisk) -> Result<u64, ResultCode> {
+pub fn get_physical_vhd_size_in_kb(virtual_disk: &VirtualDisk) -> WinResult<u64> {
     let info_wrapper = virtual_disk.get_information(get_virtual_disk::InfoVersion::Size)?;
     unsafe { Ok(info_wrapper.info().version_details.size.physical_size / 1024) }
 }
 
 /// Opens the disk backed by the secified VHD.
-pub fn open_vhd_backed_disk(virtual_disk: &VirtualDisk) -> Result<Disk, ResultCode> {
+pub fn open_vhd_backed_disk(virtual_disk: &VirtualDisk) -> WinResult<Disk> {
     let disk_path = virtual_disk.get_physical_path()?;
     Disk::open(
         &disk_path,
@@ -397,7 +387,7 @@ pub fn open_vhd_backed_disk(virtual_disk: &VirtualDisk) -> Result<Disk, ResultCo
 /// than the requested size.
 /// Returns true if the VHD was expanded, false if the current size of the VHD is already greater
 /// than or equal to the specified new size.
-pub fn expand_vhd(virtual_disk: &VirtualDisk, new_size: u64) -> Result<bool, ResultCode> {
+pub fn expand_vhd(virtual_disk: &VirtualDisk, new_size: u64) -> WinResult<bool> {
     let info_wrapper = virtual_disk.get_information(get_virtual_disk::InfoVersion::Size)?;
 
     if unsafe { info_wrapper.info().version_details.size.virtual_size } < new_size {
@@ -429,7 +419,7 @@ pub fn expand_vhd(virtual_disk: &VirtualDisk, new_size: u64) -> Result<bool, Res
                 &mut bytes,
                 std::ptr::null_mut(),
             ) {
-                0 => Err(error_code_to_result_code(
+                0 => Err(error_code_to_winresult_code(
                     winapi::um::errhandlingapi::GetLastError(),
                 )),
                 _ => Ok(true),
@@ -442,7 +432,7 @@ pub fn expand_vhd(virtual_disk: &VirtualDisk, new_size: u64) -> Result<bool, Res
 
 /// Merges a differencing disk into its immediate parent. This function should be called with caution,
 /// there might be destructive side effects if the parent disk has other child disks.
-pub fn merge_diff_vhd(virtual_disk: &VirtualDisk) -> Result<(), ResultCode> {
+pub fn merge_diff_vhd(virtual_disk: &VirtualDisk) -> WinResult<()> {
     let event = WinEvent::create(false, false, None, None)?;
     let mut overlapped = unsafe { std::mem::zeroed::<Overlapped>() };
     overlapped.hEvent = event.get_handle();
@@ -459,8 +449,8 @@ pub fn merge_diff_vhd(virtual_disk: &VirtualDisk) -> Result<(), ResultCode> {
         &parameters,
         Some(&overlapped),
     ) {
-        Err(ResultCode::ErrorIoPending) => wait_for_vhd_operation(&virtual_disk, &overlapped),
-        Err(ResultCode::ErrorSuccess) => {
+        Err(WinResultCode::ErrorIoPending) => wait_for_vhd_operation(&virtual_disk, &overlapped),
+        Err(WinResultCode::ErrorSuccess) => {
             panic!("Success case on a merge call with overlapped struct is unexpected!")
         }
         Err(error) => Err(error),
@@ -472,7 +462,7 @@ pub fn merge_diff_vhd(virtual_disk: &VirtualDisk) -> Result<(), ResultCode> {
 pub fn wait_for_vhd_operation(
     virtual_disk: &VirtualDisk,
     overlapped: &Overlapped,
-) -> Result<(), ResultCode> {
+) -> WinResult<()> {
     loop {
         let progress = virtual_disk.get_operation_progress(overlapped)?;
 
@@ -486,11 +476,11 @@ pub fn wait_for_vhd_operation(
             }
             winapi::shared::winerror::ERROR_OPERATION_ABORTED => {
                 // Job was canceled
-                return Err(ResultCode::ErrorOperationAborted);
+                return Err(WinResultCode::ErrorOperationAborted);
             }
             error => {
                 // Job failed
-                return Err(error_code_to_result_code(error));
+                return Err(error_code_to_winresult_code(error));
             }
         }
 

--- a/src/vhdutilities.rs
+++ b/src/vhdutilities.rs
@@ -66,6 +66,8 @@ pub fn mount_vhd(virtual_disk: &VirtualDisk, flags: u32, cache_mode: u16) -> Win
         internal_reserved_flags: UShort,
         cache_mode: UShort,
         qos_flow_id: Guid,
+        restricted_offset: u64,
+        restricted_length: u64,
     }
 
     unsafe {
@@ -102,7 +104,7 @@ pub fn mount_vhd(virtual_disk: &VirtualDisk, flags: u32, cache_mode: u16) -> Win
     }
 }
 
-/// Mounts a VHD with temporarily lifetime and without respecting flushes.
+/// Mounts a VHD with temporary lifetime and without respecting flushes.
 /// The expectation is that this is only called during setup, where if there is
 /// a power failure the file would be deleted anyway.
 pub fn mount_vhd_temporarily_for_setup(virtual_disk: &VirtualDisk) -> WinResult<()> {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -23,6 +23,39 @@ impl<'a> std::ops::Drop for DeleteDiskScopeExit<'a> {
 }
 
 #[test]
+fn can_create_plain_vhd() {
+    let disk_path = String::from("can_create_plain_vhd.vhdx");
+    let _delete_file_scope_exit = DeleteDiskScopeExit {
+        filepath: &disk_path,
+    };
+
+    let _virtual_disk = create_vhd(&disk_path, 1, 1).unwrap();
+}
+
+#[test]
+fn can_temporarily_mount_plain_vhd() {
+    let disk_path = String::from("can_temporarily_mount_plain_vhd.vhdx");
+    let _delete_file_scope_exit = DeleteDiskScopeExit {
+        filepath: &disk_path,
+    };
+
+    let virtual_disk = create_vhd(&disk_path, 1, 1).unwrap();
+    mount_vhd_temporarily_for_setup(&virtual_disk).unwrap();
+}
+
+#[test]
+fn can_open_temporarily_mounted_plain_vhd() {
+    let disk_path = String::from("can_open_temporarily_mounted_plain_vhd.vhdx");
+    let _delete_file_scope_exit = DeleteDiskScopeExit {
+        filepath: &disk_path,
+    };
+
+    let virtual_disk = create_vhd(&disk_path, 1, 1).unwrap();
+    mount_vhd_temporarily_for_setup(&virtual_disk).unwrap();
+    let _disk = open_vhd_backed_disk(&virtual_disk).unwrap();
+}
+
+#[test]
 fn can_create_base_vhd() {
     let disk_path = String::from("can_create_base_vhd.vhdx");
     let _delete_file_scope_exit = DeleteDiskScopeExit {


### PR DESCRIPTION
- Updates to latest winutils-rs crate
- Removes usage of deprecated function
- Added more finely grained tests
- Updated windows 10 sdk dependency to 10.0.18632.0
- Fixed subtle dependencies to Windows RS5